### PR TITLE
Add imagePullPolicy

### DIFF
--- a/deployment/web-app.yaml
+++ b/deployment/web-app.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
       - name: fresko
         image: ghcr.io/granolaameobi/fresko/fresko:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 5000
 


### PR DESCRIPTION
# Overview

Add imagePullPolicy to Kubernetes manifest so, when applied, the new docker image is deployed.